### PR TITLE
Add home and online lobby screens

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,22 +3,29 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
+import { GameLobbyProvider } from '@/context/GameLobbyContext';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 
 export const unstable_settings = {
-  anchor: '(tabs)',
+  initialRouteName: 'index',
 };
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
-      </Stack>
-      <StatusBar style="auto" />
-    </ThemeProvider>
+    <GameLobbyProvider>
+      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+        <Stack initialRouteName="index">
+          <Stack.Screen name="index" options={{ headerShown: false }} />
+          <Stack.Screen name="local-play" options={{ title: 'Local Play' }} />
+          <Stack.Screen name="online/index" options={{ title: 'Online Games' }} />
+          <Stack.Screen name="online/create" options={{ title: 'Create Game' }} />
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
+        </Stack>
+        <StatusBar style="auto" />
+      </ThemeProvider>
+    </GameLobbyProvider>
   );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,118 @@
+import { useRouter } from 'expo-router';
+import { Pressable, StyleSheet, View } from 'react-native';
+
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { Colors } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+const actions = [
+  {
+    key: 'local',
+    title: 'Local Match',
+    description: 'Challenge a friend on the same device with the classic board.',
+    route: '/local-play',
+  },
+  {
+    key: 'online',
+    title: 'Online Lobby',
+    description: 'Browse open rooms and join an online opponent.',
+    route: '/online',
+  },
+  {
+    key: 'create',
+    title: 'Create Game',
+    description: 'Host a new online room and invite other players to join.',
+    route: '/online/create',
+  },
+] as const;
+
+type Action = (typeof actions)[number];
+
+function HomeActionButton({ action, onPress }: { action: Action; onPress: (route: string) => void }) {
+  const colorScheme = useColorScheme() ?? 'light';
+  const tintColor = Colors[colorScheme].tint;
+  const textColor = colorScheme === 'dark' ? Colors.dark.background : '#fff';
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityHint={action.description}
+      onPress={() => onPress(action.route)}
+      style={({ pressed }) => [styles.actionButton, { backgroundColor: tintColor }, pressed && styles.actionButtonPressed]}>
+      <ThemedText type="subtitle" style={[styles.actionButtonTitle, { color: textColor }]}>
+        {action.title}
+      </ThemedText>
+      <ThemedText style={[styles.actionButtonDescription, { color: textColor }]}>
+        {action.description}
+      </ThemedText>
+    </Pressable>
+  );
+}
+
+export default function HomeScreen() {
+  const router = useRouter();
+
+  return (
+    <ThemedView style={styles.container}>
+      <View style={styles.content}>
+        <View style={styles.header}>
+          <ThemedText type="title" style={styles.title}>
+            Path Blocker
+          </ThemedText>
+          <ThemedText style={styles.subtitle}>
+            Choose how you want to play and jump into the action.
+          </ThemedText>
+        </View>
+        <View style={styles.actions}>
+          {actions.map((action) => (
+            <HomeActionButton key={action.key} action={action} onPress={(route) => router.push(route)} />
+          ))}
+        </View>
+      </View>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingTop: 64,
+    paddingBottom: 48,
+    justifyContent: 'space-between',
+  },
+  header: {
+    gap: 16,
+  },
+  title: {
+    textAlign: 'center',
+  },
+  subtitle: {
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+  actions: {
+    gap: 16,
+  },
+  actionButton: {
+    borderRadius: 16,
+    paddingHorizontal: 20,
+    paddingVertical: 18,
+    gap: 8,
+  },
+  actionButtonTitle: {
+    textAlign: 'left',
+  },
+  actionButtonDescription: {
+    fontSize: 14,
+    lineHeight: 20,
+    opacity: 0.9,
+  },
+  actionButtonPressed: {
+    transform: [{ scale: 0.99 }],
+  },
+});

--- a/app/local-play.tsx
+++ b/app/local-play.tsx
@@ -1,0 +1,5 @@
+import { QuoridorGame } from '@/components/quoridor/QuoridorGame';
+
+export default function LocalPlayScreen() {
+  return <QuoridorGame />;
+}

--- a/app/online/create.tsx
+++ b/app/online/create.tsx
@@ -1,0 +1,130 @@
+import { useRouter } from 'expo-router';
+import { useState } from 'react';
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  StyleSheet,
+  TextInput,
+  View,
+} from 'react-native';
+
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { Colors } from '@/constants/theme';
+import { useGameLobby } from '@/context/GameLobbyContext';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+export default function CreateGameScreen() {
+  const [gameName, setGameName] = useState('');
+  const router = useRouter();
+  const { createGame } = useGameLobby();
+  const colorScheme = useColorScheme() ?? 'light';
+  const accentColor = Colors[colorScheme].tint;
+  const textColor = Colors[colorScheme].text;
+  const buttonTextColor = colorScheme === 'dark' ? Colors.dark.background : '#fff';
+  const placeholderColor = colorScheme === 'dark' ? '#9BA1A6' : '#6B7280';
+
+  const isDisabled = gameName.trim().length === 0;
+
+  const handleCreate = () => {
+    try {
+      const newGame = createGame(gameName);
+      setGameName('');
+      Alert.alert('Game created', `"${newGame.name}" is now visible in the online lobby.`, [
+        {
+          text: 'View games',
+          onPress: () => router.replace('/online'),
+        },
+      ]);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Please enter a valid name.';
+      Alert.alert('Cannot create game', message);
+    }
+  };
+
+  return (
+    <ThemedView style={styles.flex}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}
+        style={styles.container}>
+        <View style={styles.header}>
+          <ThemedText type="title" style={styles.title}>
+            Create a game
+          </ThemedText>
+          <ThemedText style={styles.subtitle}>
+            Choose a name so other players can recognize your room in the lobby.
+          </ThemedText>
+        </View>
+        <View style={styles.form}>
+          <ThemedText type="defaultSemiBold">Game name</ThemedText>
+          <TextInput
+            value={gameName}
+            onChangeText={setGameName}
+            placeholder="e.g. Saturday Showdown"
+            placeholderTextColor={placeholderColor}
+            style={[styles.input, { borderColor: accentColor, color: textColor }]}
+            returnKeyType="done"
+            onSubmitEditing={handleCreate}
+          />
+          <Pressable
+            onPress={handleCreate}
+            disabled={isDisabled}
+            style={({ pressed }) => [
+              styles.submitButton,
+              {
+                backgroundColor: accentColor,
+                opacity: isDisabled ? 0.5 : pressed ? 0.85 : 1,
+              },
+            ]}>
+            <ThemedText type="defaultSemiBold" style={[styles.submitButtonText, { color: buttonTextColor }]}>
+              Create game
+            </ThemedText>
+          </Pressable>
+        </View>
+      </KeyboardAvoidingView>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  container: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingTop: 32,
+    paddingBottom: 24,
+    justifyContent: 'space-between',
+  },
+  header: {
+    gap: 12,
+  },
+  title: {
+    textAlign: 'center',
+  },
+  subtitle: {
+    textAlign: 'center',
+  },
+  form: {
+    gap: 16,
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: Platform.select({ ios: 14, default: 12 }),
+    fontSize: 16,
+  },
+  submitButton: {
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  submitButtonText: {
+    textAlign: 'center',
+  },
+});

--- a/app/online/index.tsx
+++ b/app/online/index.tsx
@@ -1,0 +1,147 @@
+import { useRouter } from 'expo-router';
+import { Alert, FlatList, Pressable, StyleSheet, View } from 'react-native';
+
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { Colors } from '@/constants/theme';
+import { useGameLobby } from '@/context/GameLobbyContext';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+type GameListItemProps = {
+  name: string;
+  players: number;
+  maxPlayers: number;
+  onPress: () => void;
+};
+
+function GameListItem({ name, players, maxPlayers, onPress }: GameListItemProps) {
+  const colorScheme = useColorScheme() ?? 'light';
+  const borderColor = Colors[colorScheme].tint;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`${name}, ${players} of ${maxPlayers} players`}
+      style={({ pressed }) => [
+        styles.gameCard,
+        { borderColor },
+        pressed && styles.gameCardPressed,
+      ]}>
+      <ThemedText type="subtitle" style={styles.gameTitle}>
+        {name}
+      </ThemedText>
+      <ThemedText style={styles.gamePlayers}>{players >= maxPlayers ? 'Full' : `${players}/${maxPlayers} players`}</ThemedText>
+    </Pressable>
+  );
+}
+
+export default function OnlineGamesScreen() {
+  const { games } = useGameLobby();
+  const router = useRouter();
+  const colorScheme = useColorScheme() ?? 'light';
+  const accentColor = Colors[colorScheme].tint;
+
+  const handleJoinGame = (gameName: string) => {
+    Alert.alert('Join Game', `Attempting to join "${gameName}"...`);
+  };
+
+  return (
+    <ThemedView style={styles.container}>
+      <View style={styles.header}>
+        <ThemedText type="title" style={styles.title}>
+          Game Lobby
+        </ThemedText>
+        <ThemedText style={styles.description}>
+          Pick a game from the list to join or create your own room.
+        </ThemedText>
+        <Pressable
+          onPress={() => router.push('/online/create')}
+          style={({ pressed }) => [
+            styles.createButton,
+            { borderColor: accentColor },
+            pressed && styles.createButtonPressed,
+          ]}>
+          <ThemedText type="defaultSemiBold" style={[styles.createButtonText, { color: accentColor }]}>
+            Create a new game
+          </ThemedText>
+        </Pressable>
+      </View>
+      <FlatList
+        data={games}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={[styles.listContent, games.length === 0 && styles.emptyListContent]}
+        renderItem={({ item }) => (
+          <GameListItem
+            name={item.name}
+            players={item.players}
+            maxPlayers={item.maxPlayers}
+            onPress={() => handleJoinGame(item.name)}
+          />
+        )}
+        ListEmptyComponent={<ThemedText style={styles.emptyText}>No games available yet. Be the first to create one!</ThemedText>}
+      />
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingTop: 24,
+    paddingBottom: 16,
+    gap: 24,
+  },
+  header: {
+    gap: 12,
+  },
+  title: {
+    textAlign: 'center',
+  },
+  description: {
+    textAlign: 'center',
+  },
+  createButton: {
+    alignSelf: 'center',
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  createButtonPressed: {
+    opacity: 0.7,
+  },
+  createButtonText: {
+    textAlign: 'center',
+  },
+  listContent: {
+    gap: 16,
+    paddingBottom: 24,
+  },
+  emptyListContent: {
+    flexGrow: 1,
+    justifyContent: 'center',
+  },
+  emptyText: {
+    textAlign: 'center',
+    opacity: 0.6,
+  },
+  gameCard: {
+    borderWidth: 1,
+    borderRadius: 16,
+    paddingHorizontal: 18,
+    paddingVertical: 16,
+    gap: 8,
+  },
+  gameCardPressed: {
+    transform: [{ scale: 0.99 }],
+  },
+  gameTitle: {
+    textAlign: 'left',
+  },
+  gamePlayers: {
+    fontSize: 14,
+    opacity: 0.7,
+  },
+});

--- a/context/GameLobbyContext.tsx
+++ b/context/GameLobbyContext.tsx
@@ -1,0 +1,60 @@
+import React, { createContext, useContext, useMemo, useState, type ReactNode } from 'react';
+
+export type LobbyGame = {
+  id: string;
+  name: string;
+  players: number;
+  maxPlayers: number;
+};
+
+type GameLobbyContextValue = {
+  games: LobbyGame[];
+  createGame: (name: string) => LobbyGame;
+};
+
+const GameLobbyContext = createContext<GameLobbyContextValue | undefined>(undefined);
+
+const initialGames: LobbyGame[] = [
+  { id: 'game-1', name: 'Evening Match', players: 1, maxPlayers: 2 },
+  { id: 'game-2', name: 'Weekend Tournament', players: 2, maxPlayers: 2 },
+  { id: 'game-3', name: 'Strategy Session', players: 1, maxPlayers: 2 },
+];
+
+function createGameFromName(name: string): LobbyGame {
+  return {
+    id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    name,
+    players: 1,
+    maxPlayers: 2,
+  };
+}
+
+export function GameLobbyProvider({ children }: { children: ReactNode }) {
+  const [games, setGames] = useState<LobbyGame[]>(initialGames);
+
+  const createGame = (name: string) => {
+    const trimmedName = name.trim();
+
+    if (!trimmedName) {
+      throw new Error('Game name is required');
+    }
+
+    const newGame = createGameFromName(trimmedName);
+    setGames((previous) => [...previous, newGame]);
+    return newGame;
+  };
+
+  const value = useMemo(() => ({ games, createGame }), [games]);
+
+  return <GameLobbyContext.Provider value={value}>{children}</GameLobbyContext.Provider>;
+}
+
+export function useGameLobby() {
+  const context = useContext(GameLobbyContext);
+
+  if (!context) {
+    throw new Error('useGameLobby must be used within a GameLobbyProvider');
+  }
+
+  return context;
+}


### PR DESCRIPTION
## Summary
- add a dedicated home screen that links to local play, online lobby, and game creation flows
- introduce a shared lobby context with online lobby and create-game screens that reuse the existing board
- update the root navigation stack with the new routes and a standalone local play screen

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc40e6f8e08328a031fc5e507e0f43