### PR TITLE
Integrate Firebase auth and Firestore features

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,29 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
    npx expo start
    ```
 
+### Connect Firebase services
+
+This project uses [Firebase Authentication](https://firebase.google.com/docs/auth) and [Cloud Firestore](https://firebase.google.com/docs/firestore) for multiplayer features. Create a Firebase project and add a web app, then provide the configuration values via environment variables (Expo automatically exposes variables prefixed with `EXPO_PUBLIC_`).
+
+Create a `.env` file in the project root that includes:
+
+```bash
+EXPO_PUBLIC_FIREBASE_API_KEY=your-api-key
+EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN=your-app.firebaseapp.com
+EXPO_PUBLIC_FIREBASE_PROJECT_ID=your-project-id
+EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET=your-app.appspot.com
+EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=sender-id
+EXPO_PUBLIC_FIREBASE_APP_ID=app-id
+```
+
+Enable Email/Password authentication in the Firebase console and create the following Firestore collections:
+
+- `users` – profile documents created automatically when players register or sign in.
+- `games` – lobby/game session metadata. Documents are created when a host sets up a room.
+- `items` – optional collection used for the featured item list on the home screen.
+
+Firestore documents are updated through the app, so no additional security rules are required for basic local development. Remember to tighten the rules before deploying to production.
+
 In the output, you'll find options to open the app in a
 
 - [development build](https://docs.expo.dev/develop/development-builds/introduction/)

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,6 +3,7 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
+import { AuthProvider } from '@/context/AuthContext';
 import { GameLobbyProvider } from '@/context/GameLobbyContext';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 
@@ -14,18 +15,23 @@ export default function RootLayout() {
   const colorScheme = useColorScheme();
 
   return (
-    <GameLobbyProvider>
-      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <Stack initialRouteName="index">
-          <Stack.Screen name="index" options={{ headerShown: false }} />
-          <Stack.Screen name="local-play" options={{ title: 'Local Play' }} />
-          <Stack.Screen name="online/index" options={{ title: 'Online Games' }} />
-          <Stack.Screen name="online/create" options={{ title: 'Create Game' }} />
-          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
-        </Stack>
-        <StatusBar style="auto" />
-      </ThemeProvider>
-    </GameLobbyProvider>
+    <AuthProvider>
+      <GameLobbyProvider>
+        <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+          <Stack initialRouteName="index">
+            <Stack.Screen name="index" options={{ headerShown: false }} />
+            <Stack.Screen name="local-play" options={{ title: 'Local Play' }} />
+            <Stack.Screen name="online/index" options={{ title: 'Online Games' }} />
+            <Stack.Screen name="online/create" options={{ title: 'Create Game' }} />
+            <Stack.Screen name="online/game/[id]" options={{ title: 'Online Match' }} />
+            <Stack.Screen name="auth/login" options={{ title: 'Sign in' }} />
+            <Stack.Screen name="auth/register" options={{ title: 'Create account' }} />
+            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
+          </Stack>
+          <StatusBar style="auto" />
+        </ThemeProvider>
+      </GameLobbyProvider>
+    </AuthProvider>
   );
 }

--- a/app/online/game/[id].tsx
+++ b/app/online/game/[id].tsx
@@ -1,0 +1,340 @@
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Alert, Pressable, ScrollView, StyleSheet, View } from 'react-native';
+
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { Colors } from '@/constants/theme';
+import { useAuth } from '@/context/AuthContext';
+import { useGameLobby } from '@/context/GameLobbyContext';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { useRealtimeGame } from '@/hooks/use-realtime-game';
+import { db } from '@/services/firebase';
+import { serverTimestamp, updateDoc, doc } from 'firebase/firestore';
+
+type RouteParams = {
+  id?: string;
+};
+
+type PlayerEntry = {
+  id: string;
+  displayName: string;
+};
+
+export default function GameSessionScreen() {
+  const { id } = useLocalSearchParams<RouteParams>();
+  const router = useRouter();
+  const gameId = typeof id === 'string' ? id : null;
+  const { gameState, loading, error } = useRealtimeGame(gameId);
+  const { user } = useAuth();
+  const { leaveGame } = useGameLobby();
+  const colorScheme = useColorScheme() ?? 'light';
+  const accentColor = Colors[colorScheme].tint;
+  const [updatingTurn, setUpdatingTurn] = useState(false);
+  const [leaving, setLeaving] = useState(false);
+
+  useEffect(() => {
+    if (!gameId) {
+      router.replace('/online');
+    }
+  }, [gameId, router]);
+
+  const currentPlayer = useMemo(() => {
+    const rawValue = (gameState?.state?.currentPlayer as string | undefined) ?? 'north';
+    return rawValue === 'south' ? 'south' : 'north';
+  }, [gameState?.state?.currentPlayer]);
+
+  const playerEntries: PlayerEntry[] = useMemo(() => {
+    if (!gameState?.players) {
+      return [];
+    }
+
+    return Object.entries(gameState.players).map(([playerId, profile]) => ({
+      id: playerId,
+      displayName:
+        (profile && typeof profile.displayName === 'string' && profile.displayName.length > 0)
+          ? profile.displayName
+          : 'Anonymous player',
+    }));
+  }, [gameState?.players]);
+
+  const handleAdvanceTurn = async () => {
+    if (!gameId || !gameState) {
+      return;
+    }
+
+    if (!user) {
+      Alert.alert('Sign in required', 'You must be signed in to sync moves online.');
+      return;
+    }
+
+    setUpdatingTurn(true);
+
+    try {
+      const nextPlayer = currentPlayer === 'north' ? 'south' : 'north';
+      const gameRef = doc(db, 'games', gameId);
+
+      await updateDoc(gameRef, {
+        'state.currentPlayer': nextPlayer,
+        'state.lastUpdatedAt': serverTimestamp(),
+      });
+    } catch (syncError) {
+      const message = syncError instanceof Error ? syncError.message : 'Unable to update the turn. Try again shortly.';
+      Alert.alert('Sync failed', message);
+    } finally {
+      setUpdatingTurn(false);
+    }
+  };
+
+  const handleLeaveGame = async () => {
+    if (!gameId) {
+      return;
+    }
+
+    if (!user) {
+      router.replace('/auth/login');
+      return;
+    }
+
+    setLeaving(true);
+    try {
+      await leaveGame(gameId);
+      router.replace('/online');
+    } catch (leaveError) {
+      const message = leaveError instanceof Error ? leaveError.message : 'Unable to leave the match.';
+      Alert.alert('Leave game', message);
+    } finally {
+      setLeaving(false);
+    }
+  };
+
+  if (!gameId) {
+    return null;
+  }
+
+  return (
+    <ScrollView contentContainerStyle={styles.scrollContainer}>
+      <ThemedView style={styles.container}>
+        {loading ? (
+          <View style={styles.loadingState}>
+            <ActivityIndicator />
+          </View>
+        ) : error ? (
+          <View style={styles.errorState}>
+            <ThemedText type="subtitle" style={styles.errorText}>
+              Unable to load the match
+            </ThemedText>
+            <ThemedText style={styles.errorMessage}>{error}</ThemedText>
+            <Pressable onPress={() => router.replace('/online')} style={({ pressed }) => [styles.backButton, pressed && styles.backButtonPressed]}>
+              <ThemedText type="defaultSemiBold">Back to lobby</ThemedText>
+            </Pressable>
+          </View>
+        ) : !gameState ? (
+          <View style={styles.errorState}>
+            <ThemedText type="subtitle">This match could not be found.</ThemedText>
+            <Pressable onPress={() => router.replace('/online')} style={({ pressed }) => [styles.backButton, pressed && styles.backButtonPressed]}>
+              <ThemedText type="defaultSemiBold">Back to lobby</ThemedText>
+            </Pressable>
+          </View>
+        ) : (
+          <>
+            <View style={styles.header}>
+              <ThemedText type="title" style={styles.title}>
+                {gameState.name}
+              </ThemedText>
+              <ThemedText style={styles.subtitle}>
+                Hosted by {gameState.hostName ?? 'Unknown host'}
+              </ThemedText>
+              <View style={[styles.statusPill, { backgroundColor: accentColor }]}>
+                <ThemedText style={styles.statusPillText}>
+                  {(gameState.status ?? 'waiting').toUpperCase()}
+                </ThemedText>
+              </View>
+            </View>
+
+            <View style={styles.card}>
+              <ThemedText type="subtitle" style={styles.cardHeading}>
+                Players in this match
+              </ThemedText>
+              {playerEntries.length === 0 ? (
+                <ThemedText style={styles.cardMessage}>No one has joined yet. Share the lobby with your friends!</ThemedText>
+              ) : (
+                playerEntries.map((player) => (
+                  <View key={player.id} style={styles.playerRow}>
+                    <View style={[styles.playerBadge, { backgroundColor: accentColor }]} />
+                    <ThemedText style={styles.playerName}>{player.displayName}</ThemedText>
+                  </View>
+                ))
+              )}
+            </View>
+
+            <View style={styles.card}>
+              <ThemedText type="subtitle" style={styles.cardHeading}>
+                Gameplay sync
+              </ThemedText>
+              <ThemedText style={styles.cardMessage}>
+                The current turn is set to <ThemedText type="defaultSemiBold">{currentPlayer.toUpperCase()}</ThemedText>. Update the
+                value below to synchronise moves across all connected devices.
+              </ThemedText>
+              <ThemedText style={styles.cardHint}>
+                Seats occupied: {(gameState.playerIds?.length ?? playerEntries.length)}/{gameState.maxPlayers ?? '—'}
+              </ThemedText>
+              <Pressable
+                accessibilityRole="button"
+                onPress={handleAdvanceTurn}
+                disabled={updatingTurn}
+                style={({ pressed }) => [
+                  styles.primaryButton,
+                  { backgroundColor: accentColor },
+                  (pressed || updatingTurn) && styles.primaryButtonPressed,
+                ]}>
+                <ThemedText type="defaultSemiBold" style={styles.primaryButtonText}>
+                  {updatingTurn ? 'Updating…' : 'Pass turn to opponent'}
+                </ThemedText>
+              </Pressable>
+            </View>
+
+            <View style={styles.card}>
+              <ThemedText type="subtitle" style={styles.cardHeading}>
+                Leave match
+              </ThemedText>
+              <ThemedText style={styles.cardMessage}>
+                Leaving removes you from the active roster so another player can take your seat in the lobby.
+              </ThemedText>
+              <Pressable
+                accessibilityRole="button"
+                onPress={handleLeaveGame}
+                disabled={leaving}
+                style={({ pressed }) => [
+                  styles.secondaryButton,
+                  pressed && styles.secondaryButtonPressed,
+                ]}>
+                <ThemedText type="defaultSemiBold" style={styles.secondaryButtonText}>
+                  {leaving ? 'Leaving…' : 'Leave game'}
+                </ThemedText>
+              </Pressable>
+            </View>
+          </>
+        )}
+      </ThemedView>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollContainer: {
+    flexGrow: 1,
+  },
+  container: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingTop: 32,
+    paddingBottom: 32,
+    gap: 24,
+  },
+  loadingState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  errorState: {
+    gap: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  errorText: {
+    textAlign: 'center',
+  },
+  errorMessage: {
+    textAlign: 'center',
+    opacity: 0.7,
+  },
+  backButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: 'rgba(0,0,0,0.2)',
+  },
+  backButtonPressed: {
+    opacity: 0.7,
+  },
+  header: {
+    alignItems: 'center',
+    gap: 8,
+  },
+  title: {
+    textAlign: 'center',
+  },
+  subtitle: {
+    textAlign: 'center',
+    opacity: 0.8,
+  },
+  statusPill: {
+    marginTop: 4,
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+  },
+  statusPillText: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  card: {
+    borderWidth: 1,
+    borderRadius: 16,
+    paddingHorizontal: 20,
+    paddingVertical: 18,
+    gap: 12,
+    borderColor: 'rgba(0,0,0,0.08)',
+  },
+  cardHeading: {
+    textAlign: 'left',
+  },
+  cardMessage: {
+    lineHeight: 20,
+  },
+  cardHint: {
+    fontSize: 12,
+    opacity: 0.7,
+  },
+  playerRow: {
+    flexDirection: 'row',
+    gap: 12,
+    alignItems: 'center',
+  },
+  playerBadge: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+  },
+  playerName: {
+    flex: 1,
+  },
+  primaryButton: {
+    paddingVertical: 12,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  primaryButtonPressed: {
+    opacity: 0.8,
+  },
+  primaryButtonText: {
+    color: '#fff',
+  },
+  secondaryButton: {
+    paddingVertical: 12,
+    borderRadius: 12,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(0,0,0,0.15)',
+  },
+  secondaryButtonPressed: {
+    opacity: 0.8,
+  },
+  secondaryButtonText: {
+    color: '#c0392b',
+  },
+});

--- a/components/quoridor/QuoridorBoard.tsx
+++ b/components/quoridor/QuoridorBoard.tsx
@@ -37,7 +37,6 @@ export function QuoridorBoard({
   const boardSize = Math.min(width - 32, 420);
   const wallThickness = Math.max(4, boardSize * 0.035);
   const cellSize = (boardSize - wallThickness * (BOARD_SIZE - 1)) / BOARD_SIZE;
-  const wallIndicatorSize = Math.max(10, wallThickness * 0.75);
 
   const palette = useMemo(() => {
     if (colorScheme === 'dark') {

--- a/components/quoridor/QuoridorGame.tsx
+++ b/components/quoridor/QuoridorGame.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { LayoutChangeEvent, Pressable, ScrollView, StyleSheet, View } from 'react-native';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
@@ -59,7 +59,6 @@ export function QuoridorGame() {
   const [wallOrientation, setWallOrientation] = useState<Orientation>('horizontal');
   const [winner, setWinner] = useState<PlayerId | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
-  const [boardContainerWidth, setBoardContainerWidth] = useState<number | null>(null);
 
   const opponent = getOpponent(currentPlayer);
 
@@ -113,19 +112,6 @@ export function QuoridorGame() {
     }
     return computeAvailableWalls(wallOrientation, walls, positions);
   }, [currentPlayer, mode, positions, wallOrientation, walls, wallsRemaining, winner]);
-
-  const handleBoardLayout = useCallback(
-    ({ nativeEvent }: LayoutChangeEvent) => {
-      const { width: layoutWidth } = nativeEvent.layout;
-      setBoardContainerWidth((previous) => {
-        if (previous !== null && Math.abs(previous - layoutWidth) < 0.5) {
-          return previous;
-        }
-        return layoutWidth;
-      });
-    },
-    [],
-  );
 
   useEffect(() => {
     if (mode !== 'wall' || winner || wallsRemaining[currentPlayer] <= 0) {
@@ -357,7 +343,7 @@ export function QuoridorGame() {
           ) : null}
         </View>
 
-        <View style={styles.boardWrapper} onLayout={handleBoardLayout}>
+        <View style={styles.boardWrapper}>
           <QuoridorBoard
             currentPlayer={currentPlayer}
             positions={positions}

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -1,0 +1,99 @@
+import React, { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import {
+  createUserWithEmailAndPassword,
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  signOut,
+  updateProfile,
+  type User,
+} from 'firebase/auth';
+import { doc, serverTimestamp, setDoc } from 'firebase/firestore';
+
+import { auth, db } from '@/services/firebase';
+
+export type AuthContextValue = {
+  user: User | null;
+  initializing: boolean;
+  register: (params: { email: string; password: string; displayName?: string }) => Promise<User>;
+  login: (params: { email: string; password: string }) => Promise<User>;
+  logout: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(auth.currentUser);
+  const [initializing, setInitializing] = useState<boolean>(true);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (nextUser) => {
+      setUser(nextUser);
+      setInitializing(false);
+    });
+
+    return unsubscribe;
+  }, []);
+
+  const register = async ({ email, password, displayName }: { email: string; password: string; displayName?: string }) => {
+    const credential = await createUserWithEmailAndPassword(auth, email, password);
+
+    if (displayName) {
+      await updateProfile(credential.user, { displayName });
+    }
+
+    const profile = {
+      uid: credential.user.uid,
+      email: credential.user.email,
+      displayName: credential.user.displayName ?? displayName ?? null,
+      createdAt: serverTimestamp(),
+      lastLoginAt: serverTimestamp(),
+    };
+
+    await setDoc(doc(db, 'users', credential.user.uid), profile, { merge: true });
+
+    return credential.user;
+  };
+
+  const login = async ({ email, password }: { email: string; password: string }) => {
+    const credential = await signInWithEmailAndPassword(auth, email, password);
+
+    await setDoc(
+      doc(db, 'users', credential.user.uid),
+      {
+        email: credential.user.email,
+        displayName: credential.user.displayName ?? null,
+        lastLoginAt: serverTimestamp(),
+      },
+      { merge: true },
+    );
+
+    return credential.user;
+  };
+
+  const logout = async () => {
+    await signOut(auth);
+  };
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      user,
+      initializing,
+      register,
+      login,
+      logout,
+    }),
+    [user, initializing],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+
+  return context;
+}

--- a/hooks/use-items.ts
+++ b/hooks/use-items.ts
@@ -1,0 +1,64 @@
+import { useEffect, useMemo, useState } from 'react';
+import { collection, onSnapshot, orderBy, query, type QueryDocumentSnapshot } from 'firebase/firestore';
+
+import { db } from '@/services/firebase';
+
+export type Item = {
+  id: string;
+  name: string;
+  rarity?: string;
+  description?: string;
+};
+
+export type UseItemsResult = {
+  items: Item[];
+  loading: boolean;
+  error: string | null;
+};
+
+function mapDocument(doc: QueryDocumentSnapshot<Record<string, unknown>>): Item {
+  const data = doc.data();
+  return {
+    id: doc.id,
+    name: typeof data.name === 'string' ? data.name : 'Unnamed item',
+    rarity: typeof data.rarity === 'string' ? data.rarity : undefined,
+    description: typeof data.description === 'string' ? data.description : undefined,
+  };
+}
+
+export function useItems(): UseItemsResult {
+  const [items, setItems] = useState<Item[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const itemsCollection = collection(db, 'items');
+    const itemsQuery = query(itemsCollection, orderBy('name', 'asc'));
+
+    const unsubscribe = onSnapshot(
+      itemsQuery,
+      (snapshot) => {
+        const documents = snapshot.docs as QueryDocumentSnapshot<Record<string, unknown>>[];
+        setItems(documents.map(mapDocument));
+        setLoading(false);
+        setError(null);
+      },
+      (snapshotError) => {
+        setItems([]);
+        setLoading(false);
+        setError(snapshotError.message);
+      },
+    );
+
+    return unsubscribe;
+  }, []);
+
+  return useMemo(
+    () => ({
+      items,
+      loading,
+      error,
+    }),
+    [error, items, loading],
+  );
+}

--- a/hooks/use-realtime-game.ts
+++ b/hooks/use-realtime-game.ts
@@ -1,0 +1,106 @@
+import { useEffect, useMemo, useState } from 'react';
+import { doc, onSnapshot, type DocumentData, type DocumentReference } from 'firebase/firestore';
+
+import { db } from '@/services/firebase';
+
+export type GamePlayer = {
+  displayName?: string | null;
+  joinedAt?: Date | null;
+};
+
+export type GameState = {
+  id: string;
+  name: string;
+  hostId?: string;
+  hostName?: string | null;
+  status?: string;
+  maxPlayers?: number;
+  playerIds?: string[];
+  players?: Record<string, GamePlayer>;
+  state?: Record<string, unknown>;
+};
+
+export type UseRealtimeGameResult = {
+  gameState: GameState | null;
+  loading: boolean;
+  error: string | null;
+};
+
+function convertTimestamps(value: unknown): unknown {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  if ('toDate' in value && typeof value.toDate === 'function') {
+    return (value as { toDate: () => Date }).toDate();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(convertTimestamps);
+  }
+
+  return Object.fromEntries(Object.entries(value).map(([key, nested]) => [key, convertTimestamps(nested)]));
+}
+
+function mapSnapshot(snapshot: DocumentData | undefined, id: string): GameState | null {
+  if (!snapshot) {
+    return null;
+  }
+
+  const data = convertTimestamps(snapshot) as Record<string, unknown>;
+
+  return {
+    id,
+    ...(data as Record<string, unknown>),
+  } as GameState;
+}
+
+export function useRealtimeGame(gameId: string | null | undefined): UseRealtimeGameResult {
+  const [gameState, setGameState] = useState<GameState | null>(null);
+  const [loading, setLoading] = useState<boolean>(Boolean(gameId));
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!gameId) {
+      setGameState(null);
+      setLoading(false);
+      return;
+    }
+
+    let reference: DocumentReference<DocumentData>;
+
+    try {
+      reference = doc(db, 'games', gameId);
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Unable to create document reference');
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    const unsubscribe = onSnapshot(
+      reference,
+      (snapshot) => {
+        setGameState(mapSnapshot(snapshot.data(), snapshot.id));
+        setError(null);
+        setLoading(false);
+      },
+      (snapshotError) => {
+        setError(snapshotError.message);
+        setGameState(null);
+        setLoading(false);
+      },
+    );
+
+    return unsubscribe;
+  }, [gameId]);
+
+  return useMemo(
+    () => ({
+      gameState,
+      loading,
+      error,
+    }),
+    [error, gameState, loading],
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.2",
+        "@react-native-async-storage/async-storage": "^1.24.0",
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
@@ -24,6 +25,7 @@
         "expo-symbols": "~1.0.7",
         "expo-system-ui": "~6.0.7",
         "expo-web-browser": "~15.0.7",
+        "firebase": "^12.3.0",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.4",
@@ -2271,6 +2273,645 @@
         "@babel/highlight": "^7.10.4"
       }
     },
+    "node_modules/@firebase/ai": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.3.0.tgz",
+      "integrity": "sha512-rVZgf4FszXPSFVIeWLE8ruLU2JDmPXw4XgghcC0x/lK9veGJIyu+DvyumjreVhW/RwD3E5cNPWxQunzylhf/6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.18",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.18.tgz",
+      "integrity": "sha512-iN7IgLvM06iFk8BeFoWqvVpRFW3Z70f+Qe2PfCJ7vPIgLPjHXDE774DhCT5Y2/ZU/ZbXPDPD60x/XPWEoZLNdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.24.tgz",
+      "integrity": "sha512-jE+kJnPG86XSqGQGhXXYt1tpTbCTED8OQJ/PQ90SEw14CuxRxx/H+lFbWA1rlFtFSsTCptAJtgyRBwr/f00vsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.18",
+        "@firebase/analytics-types": "0.8.3",
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.3.tgz",
+      "integrity": "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.3.tgz",
+      "integrity": "sha512-by1leTfZkwGycPKRWpc+p5/IhpnOj8zaScVi4RRm9fMoFYS3IE87Wzx1Yf/ruVYowXOEuLqYY3VmJw5tU3+0Bg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.0.tgz",
+      "integrity": "sha512-XAvALQayUMBJo58U/rxW02IhsesaxxfWVmVkauZvGEz3vOAjMEQnzFlyblqkc2iAaO82uJ2ZVyZv9XzPfxjJ6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.0.tgz",
+      "integrity": "sha512-UfK2Q8RJNjYM/8MFORltZRG9lJj11k0nW84rrffiKvcJxLf1jf6IEjCIkCamykHE73C6BwqhVfhIBs69GXQV0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.11.0",
+        "@firebase/app-check-types": "0.5.3",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
+      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.3.tgz",
+      "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.3.tgz",
+      "integrity": "sha512-rRK9YOvgsAU/+edjgubL1q1FyCMjBZZs+fAWtD36tklawkh6WZV07sNLVSceuni+a21oby6xoad+3R8dfztOrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.14.3",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
+      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.11.0.tgz",
+      "integrity": "sha512-5j7+ua93X+IRcJ1oMDTClTo85l7Xe40WSkoJ+shzPrX7OISlVWLdE1mKC57PSD+/LfAbdhJmvKixINBw2ESK6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^1.18.1"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.0.tgz",
+      "integrity": "sha512-J0lGSxXlG/lYVi45wbpPhcWiWUMXevY4fvLZsN1GHh+po7TZVng+figdHBVhFheaiipU8HZyc7ljw1jNojM2nw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.11.0",
+        "@firebase/auth-types": "0.13.0",
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
+      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.0.tgz",
+      "integrity": "sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.0.tgz",
+      "integrity": "sha512-wR9En2A+WESUHexjmRHkqtaVH94WLNKt6rmeqZhSLBybg4Wyf0Umk04SZsS6sBq4102ZsDBFwoqMqJYj2IoDSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.11.tgz",
+      "integrity": "sha512-G258eLzAD6im9Bsw+Qm1Z+P4x0PGNQ45yeUuuqe5M9B1rn0RJvvsQCRHXgE52Z+n9+WX1OJd/crcuunvOGc7Vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.0.tgz",
+      "integrity": "sha512-gM6MJFae3pTyNLoc9VcJNuaUDej0ctdjn3cVtILo3D5lpp0dmUHHLFN/pUKe7ImyeB1KAvRlEYxvIHNF04Filg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.0.tgz",
+      "integrity": "sha512-8nYc43RqxScsePVd1qe1xxvWNf0OBnbwHxmXJ7MHSuuTVYFO3eLyLW3PiCKJ9fHnmIz4p4LbieXwz+qtr9PZDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/database": "1.1.0",
+        "@firebase/database-types": "1.0.16",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.16.tgz",
+      "integrity": "sha512-xkQLQfU5De7+SPhEGAXFBnDryUWhhlFXelEg2YeZOQMCdoe7dL64DDAd77SQsR+6uoXIZY5MB4y/inCs4GTfcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.3",
+        "@firebase/util": "1.13.0"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.9.2.tgz",
+      "integrity": "sha512-iuA5+nVr/IV/Thm0Luoqf2mERUvK9g791FZpUJV1ZGXO6RL2/i/WFJUj5ZTVXy5pRjpWYO+ZzPcReNrlilmztA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "@firebase/webchannel-wrapper": "1.0.5",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.2.tgz",
+      "integrity": "sha512-cy7ov6SpFBx+PHwFdOOjbI7kH00uNKmIFurAn560WiPCZXy9EMnil1SOG7VF4hHZKdenC+AHtL4r3fNpirpm0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/firestore": "4.9.2",
+        "@firebase/firestore-types": "3.0.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.3.tgz",
+      "integrity": "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.1.tgz",
+      "integrity": "sha512-sUeWSb0rw5T+6wuV2o9XNmh9yHxjFI9zVGFnjFi+n7drTEWpl7ZTz1nROgGrSu472r+LAaj+2YaSicD4R8wfbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.0",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.1.tgz",
+      "integrity": "sha512-AxxUBXKuPrWaVNQ8o1cG1GaCAtXT8a0eaTDfqgS5VsRYLAR0ALcfqDLwo/QyijZj1w8Qf8n3Qrfy/+Im245hOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/functions": "0.13.1",
+        "@firebase/functions-types": "0.6.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.3.tgz",
+      "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.19",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.19.tgz",
+      "integrity": "sha512-nGDmiwKLI1lerhwfwSHvMR9RZuIH5/8E3kgUWnVRqqL7kGVSktjLTWEMva7oh5yxQ3zXfIlIwJwMcaM5bK5j8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.19.tgz",
+      "integrity": "sha512-khfzIY3EI5LePePo7vT19/VEIH1E3iYsHknI/6ek9T8QCozAZshWT9CjlwOzZrKvTHMeNcbpo/VSOSIWDSjWdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/installations-types": "0.5.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.3.tgz",
+      "integrity": "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.0.tgz",
+      "integrity": "sha512-cGskaAvkrnh42b3BA3doDWeBmuHFO/Mx5A83rbRDYakPjO9bJtRL3dX7javzc2Rr/JHZf4HlterTW2lUkfeN4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.23",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.23.tgz",
+      "integrity": "sha512-cfuzv47XxqW4HH/OcR5rM+AlQd1xL/VhuaeW/wzMW1LFrsFcTn0GND/hak1vkQc2th8UisBcrkVcQAnOnKwYxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.13.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.23.tgz",
+      "integrity": "sha512-SN857v/kBUvlQ9X/UjAqBoQ2FEaL1ZozpnmL1ByTe57iXkmnVVFm9KqAsTfmf+OEwWI4kJJe9NObtN/w22lUgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/messaging": "0.12.23",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
+      "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.9.tgz",
+      "integrity": "sha512-UzybENl1EdM2I1sjYm74xGt/0JzRnU/0VmfMAKo2LSpHJzaj77FCLZXmYQ4oOuE+Pxtt8Wy2BVJEENiZkaZAzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.22.tgz",
+      "integrity": "sha512-xLKxaSAl/FVi10wDX/CHIYEUP13jXUjinL+UaNXT9ByIvxII5Ne5150mx6IgM8G6Q3V+sPiw9C8/kygkyHUVxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/performance": "0.7.9",
+        "@firebase/performance-types": "0.2.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.3.tgz",
+      "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.7.0.tgz",
+      "integrity": "sha512-dX95X6WlW7QlgNd7aaGdjAIZUiQkgWgNS+aKNu4Wv92H1T8Ue/NDUjZHd9xb8fHxLXIHNZeco9/qbZzr500MjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.20.tgz",
+      "integrity": "sha512-P/ULS9vU35EL9maG7xp66uljkZgcPMQOxLj3Zx2F289baTKSInE6+YIkgHEi1TwHoddC/AFePXPpshPlEFkbgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/remote-config": "0.7.0",
+        "@firebase/remote-config-types": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.0.tgz",
+      "integrity": "sha512-vI3bqLoF14L/GchtgayMiFpZJF+Ao3uR8WCde0XpYNkSokDpAKca2DxvcfeZv7lZUqkUwQPL2wD83d3vQ4vvrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.0.tgz",
+      "integrity": "sha512-xWWbb15o6/pWEw8H01UQ1dC5U3rf8QTAzOChYyCpafV6Xki7KVp3Yaw2nSklUwHEziSWE9KoZJS7iYeyqWnYFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.0.tgz",
+      "integrity": "sha512-vDzhgGczr1OfcOy285YAPur5pWDEvD67w4thyeCUh6Ys0izN9fNYtA1MJERmNBfqjqu0lg0FM5GLbw0Il21M+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/storage": "0.14.0",
+        "@firebase/storage-types": "0.8.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.3.tgz",
+      "integrity": "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.13.0.tgz",
+      "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.5.tgz",
+      "integrity": "sha512-+uGNN7rkfn41HLO0vekTFhTxk61eKa8mTpRGLO0QSqlQdKvIoGAvLp3ppdVIWbTGYJWM6Kp0iN+PjMIOcnVqTw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2693,6 +3334,70 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
@@ -3179,6 +3884,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
+      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -7201,6 +7918,18 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -7321,6 +8050,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.3.0.tgz",
+      "integrity": "sha512-/JVja0IDO8zPETGv4TvvBwo7RwcQFz+RQ3JBETNtUSeqsDdI9G7fhRTkCy1sPKnLzW0xpm/kL8GOj6ncndTT3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.3.0",
+        "@firebase/analytics": "0.10.18",
+        "@firebase/analytics-compat": "0.2.24",
+        "@firebase/app": "0.14.3",
+        "@firebase/app-check": "0.11.0",
+        "@firebase/app-check-compat": "0.4.0",
+        "@firebase/app-compat": "0.5.3",
+        "@firebase/app-types": "0.9.3",
+        "@firebase/auth": "1.11.0",
+        "@firebase/auth-compat": "0.6.0",
+        "@firebase/data-connect": "0.3.11",
+        "@firebase/database": "1.1.0",
+        "@firebase/database-compat": "2.1.0",
+        "@firebase/firestore": "4.9.2",
+        "@firebase/firestore-compat": "0.4.2",
+        "@firebase/functions": "0.13.1",
+        "@firebase/functions-compat": "0.4.1",
+        "@firebase/installations": "0.6.19",
+        "@firebase/installations-compat": "0.2.19",
+        "@firebase/messaging": "0.12.23",
+        "@firebase/messaging-compat": "0.2.23",
+        "@firebase/performance": "0.7.9",
+        "@firebase/performance-compat": "0.2.22",
+        "@firebase/remote-config": "0.7.0",
+        "@firebase/remote-config-compat": "0.2.20",
+        "@firebase/storage": "0.14.0",
+        "@firebase/storage-compat": "0.4.0",
+        "@firebase/util": "1.13.0"
       }
     },
     "node_modules/flat-cache": {
@@ -7871,6 +8636,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -7889,6 +8660,12 @@
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -8330,6 +9107,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-regex": {
@@ -9155,6 +9941,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -9257,6 +10049,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -9308,6 +10106,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -10549,6 +11359,30 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -12962,11 +13796,40 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.2",
+    "@react-native-async-storage/async-storage": "^1.24.0",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
@@ -27,6 +28,7 @@
     "expo-symbols": "~1.0.7",
     "expo-system-ui": "~6.0.7",
     "expo-web-browser": "~15.0.7",
+    "firebase": "^12.3.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.4",

--- a/services/firebase.ts
+++ b/services/firebase.ts
@@ -1,0 +1,82 @@
+import { getApp, getApps, initializeApp, type FirebaseApp } from 'firebase/app';
+import {
+  getAuth,
+  initializeAuth,
+  type Auth,
+  getReactNativePersistence,
+} from 'firebase/auth';
+import { getFirestore, type Firestore } from 'firebase/firestore';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Platform } from 'react-native';
+
+function createFirebaseConfig() {
+  const config = {
+    apiKey: process.env.EXPO_PUBLIC_FIREBASE_API_KEY,
+    authDomain: process.env.EXPO_FIREBASE_AUTH_DOMAIN ?? process.env.EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN,
+    projectId: process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID,
+    storageBucket: process.env.EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET,
+    messagingSenderId: process.env.EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+    appId: process.env.EXPO_PUBLIC_FIREBASE_APP_ID,
+  } as const;
+
+  const missing = Object.entries(config)
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+
+  if (missing.length > 0) {
+    console.warn(
+      `Firebase configuration is incomplete. Missing: ${missing.join(', ')}. Double-check your environment variables.`,
+    );
+  }
+
+  return config;
+}
+
+let firebaseApp: FirebaseApp;
+let firebaseAuth: Auth;
+let firestore: Firestore;
+
+function ensureFirebaseApp(): FirebaseApp {
+  if (!firebaseApp) {
+    const config = createFirebaseConfig();
+    firebaseApp = getApps().length > 0 ? getApp() : initializeApp(config);
+  }
+
+  return firebaseApp;
+}
+
+function ensureAuth(app: FirebaseApp): Auth {
+  if (firebaseAuth) {
+    return firebaseAuth;
+  }
+
+  if (Platform.OS === 'web') {
+    firebaseAuth = getAuth(app);
+    return firebaseAuth;
+  }
+
+  try {
+    firebaseAuth = initializeAuth(app, {
+      persistence: getReactNativePersistence(AsyncStorage),
+    });
+  } catch (error) {
+    // initializeAuth can only be called once per app instance. If it throws, fall back to the default auth instance.
+    firebaseAuth = getAuth(app);
+  }
+
+  return firebaseAuth;
+}
+
+function ensureFirestore(app: FirebaseApp): Firestore {
+  if (!firestore) {
+    firestore = getFirestore(app);
+  }
+
+  return firestore;
+}
+
+const app = ensureFirebaseApp();
+const auth = ensureAuth(app);
+const db = ensureFirestore(app);
+
+export { app, auth, db };


### PR DESCRIPTION
## Summary
- configure Firebase app initialization with async storage persistence for auth and export Firestore helpers
- add auth context plus sign-in and registration screens that create user documents and gate online actions
- migrate game lobby state to Firestore with real-time listeners, add an online game session screen, and surface Firestore-driven items on the home screen
- document required Firebase environment variables and collections

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd49c8e83883289199df77d6d01238