### PR TITLE
Seed lobby with AI matches when empty and run hidden AI opponent

### DIFF
--- a/app/online/index.tsx
+++ b/app/online/index.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'expo-router';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ActivityIndicator, Alert, FlatList, Pressable, StyleSheet, View, ImageBackground } from 'react-native';
 
 import { ThemedText } from '@/components/themed-text';
@@ -42,9 +42,15 @@ function GameListItem({ name, players, maxPlayers, status, isPrivate, onPress, d
 }
 
 export default function OnlineGamesScreen() {
-  const { games, loading, joinGame } = useGameLobby();
+  const { games, loading, joinGame, ensureAIGameAvailability } = useGameLobby();
   const router = useRouter();
   const [joiningGameId, setJoiningGameId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!loading) {
+      void ensureAIGameAvailability();
+    }
+  }, [ensureAIGameAvailability, games, loading]);
 
   const handleJoinGame = async (gameId: string, isPrivate?: boolean) => {
     if (isPrivate) {

--- a/hooks/use-realtime-game.ts
+++ b/hooks/use-realtime-game.ts
@@ -32,6 +32,12 @@ export type GameState = {
   newGameId?: string;
   oldGameId?: string;
   state?: Record<string, unknown>;
+  aiMatch?: {
+    enabled?: boolean;
+    difficulty?: string;
+    aiPlayerId?: string;
+    aiName?: string;
+  };
 };
 
 export type UseRealtimeGameResult = {


### PR DESCRIPTION
## Summary
- seed the lobby with a hidden hard-AI host when no public games are available and expose a helper to maintain availability
- tag AI-backed matches in realtime state, adjust join/leave flows to mark the bot ready, and keep rematches seamless without revealing the AI
- extend the Quoridor AI to play from either side and drive automated turns, rematch votes, and stat handling for the disguised opponent

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68da7c35b71083288d5e62e1fcb635ab